### PR TITLE
grate version bump to 1.6.2

### DIFF
--- a/demo/frosting/build/Program.cs
+++ b/demo/frosting/build/Program.cs
@@ -10,7 +10,7 @@ public static class Program
     public static int Main(string[] args)
     {
         return new CakeHost()
-            .InstallTool(new Uri("dotnet:?package=grate&version=1.5.4"))
+            .InstallTool(new Uri("dotnet:?package=grate&version=1.6.2"))
             .Run(args);
     }
 }

--- a/demo/script/build.cake
+++ b/demo/script/build.cake
@@ -1,5 +1,5 @@
 
-#tool "dotnet:?package=grate&version=1.5.4"
+#tool "dotnet:?package=grate&version=1.6.2"
 #r "..\..\src\Cake.grate\bin\Debug\net8.0\Cake.grate.dll"
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ From the grate documentation:
 
 - [Install](#install)
 - [Usage](#usage)
+- [Compatibility](#compatibility)
 
 
 ## Install
@@ -24,7 +25,7 @@ From the grate documentation:
 ## Usage
 
 ```cs
-#tool "dotnet:?package=grate&version=1.5.4"
+#tool "dotnet:?package=grate&version=1.6.2"
 #addin nuget:?package=Cake.grate
 
 Task("MyTask").Does(() => {
@@ -34,6 +35,13 @@ Task("MyTask").Does(() => {
     });
 });
 ```
+
+## Compatibility
+
+The version number of Cake.grate keeps in step with the versions released by [grate](https://github.com/erikbra/grate/releases), e.g. 1.6.2 of Cake.grate has been tested against and contains the features of grate version 1.6.2.
+
+However, providing there are no breaking changes in a more recent grate version, it is likely Cake.grate will be compatible with it, just specify grate version in the `tool` referenc
+
 [githubbuild]: https://github.com/cake-contrib/Cake.grate/actions/workflows/build.yml?query=branch%3Amain
 [githubimage]: https://github.com/cake-contrib/Cake.grate/actions/workflows/build.yml/badge.svg?branch=main
 [nuget]: https://nuget.org/packages/Cake.grate


### PR DESCRIPTION
Tested and updated references to grate 1.6.2. 
I didn't go to version 1.7.0 because there are new features that need reviewing and potentially adding.

See issue #7 